### PR TITLE
fix(badges): update based on event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,29 @@ it reaches `1.0.0`.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-21
+
+### Fixed
+
+- Container state (`running`/`exited`/`paused`, ...) could go stale on the
+  Containers page for up to the full check interval (30 minutes by
+  default) after a container was started, stopped, or killed outside
+  DoUpRo — e.g. manually via `docker start` after a host reboot. The
+  crash-loop monitor's already-open Docker event stream now updates a
+  container's stored state immediately on `start`/`stop`/`kill`/`die`/
+  `pause`/`unpause`/`oom`, independent of crash-loop detection; the
+  periodic check remains the fallback for anything the event stream
+  misses (reconnect gaps, daemon restarts).
+- A missing `rows.Err()` check after the plaintext-secret migration's
+  `notification_queue` scan loop meant an interrupted iteration (as
+  opposed to a clean end-of-rows) was silently swallowed, letting the
+  migration transaction commit having encrypted only part of the queued
+  secrets.
+
+## [0.2.0] - 2026-08-17
+
 Everything below shipped after the `0.1.0` tag, verified end-to-end
-against a real homelab, not just unit tests. Not yet re-tagged.
+against a real homelab, not just unit tests.
 
 ### Added
 
@@ -172,17 +193,3 @@ tests) — not a scaffold anymore.
   none of the three surfaces can ever behave differently.
 - Docker packaging: multi-stage `Dockerfile` (distroless, non-root),
   `docker-compose.yml`, `.env.example`.
-
-### Known gaps (tracked, not yet built)
-
-- No multi-user roles — every authenticated identity (local or OIDC) has
-  full access. Design is locked (3 permission levels + fine-grained
-  checkboxes); implementation is next.
-- No Unix-socket local CLI mode — every CLI invocation (including via
-  `docker exec`) needs `--host`/`--api-key`, same as a remote caller.
-- No semver bump-policy target selection — update detection is
-  digest-only (catches a moved tag, not "a newer tag exists").
-  `relative` + `delayed` recurring policy is creatable but not yet
-  executed by the scheduler.
-- No automatic rollback on crash-loop yet (needs a Docker event stream
-  watcher — only manual Update/Rollback exist).

--- a/internal/crashloop/monitor.go
+++ b/internal/crashloop/monitor.go
@@ -118,6 +118,8 @@ func (m *Monitor) reconcile(ctx context.Context) time.Time {
 }
 
 func (m *Monitor) handleEvent(ctx context.Context, event docker.ContainerEvent) {
+	m.syncState(ctx, event)
+
 	if event.Action != "die" || event.Name == "" {
 		return
 	}
@@ -131,6 +133,40 @@ func (m *Monitor) handleEvent(ctx context.Context, event docker.ContainerEvent) 
 		eventNano = event.Time.UnixNano()
 	}
 	m.recordCrash(ctx, event.Name, event.ContainerID, eventNano, event.Time, "docker_event")
+}
+
+// lifecycleState maps the subset of Docker container-event actions that
+// change the running state into the same State strings docker.Client.List
+// (and thus the Containers page) already uses, so a manual `docker
+// start`/`stop`/`kill` outside DoUpRo shows up in the UI immediately instead
+// of only after the next periodic scheduler.Check() tick (up to
+// DefaultCheckInterval later — see internal/scheduler/scheduler.go). Actions
+// with no running-state effect for our purposes (e.g. "create", "rename")
+// are left unmapped and ignored.
+var lifecycleState = map[string]string{
+	"start":   "running",
+	"unpause": "running",
+	"die":     "exited",
+	"stop":    "exited",
+	"kill":    "exited",
+	"pause":   "paused",
+	"oom":     "exited",
+}
+
+// syncState reflects a container's running state into the store as soon as
+// Docker reports it, independent of crash-loop tracking. Best-effort: a
+// stale row here is corrected by the next periodic Check() regardless, so a
+// store error is logged and swallowed rather than disrupting event
+// processing for the rest of the stream.
+func (m *Monitor) syncState(ctx context.Context, event docker.ContainerEvent) {
+	state, ok := lifecycleState[event.Action]
+	if !ok || event.ContainerID == "" {
+		return
+	}
+	if err := m.store.SetContainerState(ctx, event.ContainerID, state, ""); err != nil {
+		m.logger.Emit(ctx, events.Event{Level: events.LevelWarn, Type: "container.sync_failed", Container: event.Name,
+			Actor: events.ActorSystem, Message: fmt.Sprintf("could not sync live state for %s: %v", event.Name, err)})
+	}
 }
 
 func (m *Monitor) recordCrash(ctx context.Context, name, id string, eventNano int64, at time.Time, source string) {

--- a/internal/store/secrets.go
+++ b/internal/store/secrets.go
@@ -116,6 +116,9 @@ func (s *Store) migratePlaintextSecrets(ctx context.Context) error {
 	if err := rows.Close(); err != nil {
 		return err
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate queued secrets: %w", err)
+	}
 	for _, u := range updates {
 		if _, err := tx.ExecContext(ctx, `UPDATE notification_queue SET channel_url=? WHERE id=?`, u.value, u.id); err != nil {
 			return err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -195,6 +195,28 @@ ON CONFLICT(id) DO UPDATE SET
 	return nil
 }
 
+// SetContainerState updates only the state (and, optionally, the
+// human-readable status) of an already-tracked container, without touching
+// any other column — used by the Docker event listener (internal/crashloop)
+// to reflect a start/stop/die immediately in the UI instead of waiting for
+// the next periodic Check() tick (up to DefaultCheckInterval later). An
+// empty status leaves the existing value alone: Docker's event stream
+// doesn't carry the "Up 3 hours"-style string List() produces, and writing
+// "" would blank a perfectly good display value until the next Check(). A
+// container DoUpRo hasn't discovered yet has no row to update, so this is a
+// silent no-op rather than an error: the next periodic Check() will insert
+// it via UpsertSeen regardless.
+func (s *Store) SetContainerState(ctx context.Context, id, state, status string) error {
+	const q = `
+UPDATE containers
+SET state = ?, status = CASE WHEN ? = '' THEN status ELSE ? END, updated_at = ?
+WHERE id = ?;`
+	if _, err := s.db.ExecContext(ctx, q, state, status, status, time.Now().UTC().Format(time.RFC3339Nano), id); err != nil {
+		return fmt.Errorf("set container state for %s: %w", id, err)
+	}
+	return nil
+}
+
 // RecoverImageReference returns the most recently logged mutable image
 // reference for a container. It repairs rows written by older releases
 // that allowed a rollback's raw/canonical digest to overwrite the original


### PR DESCRIPTION
## Summary

After a Docker host reboot, containers that came back up in a non-running
state (or were manually restarted with `docker start` outside DoUpRo)
kept showing their stale pre-reboot status on the Containers page —
refreshing the page changed nothing. Root cause: container state/status
was only ever written to SQLite by the periodic `scheduler.Check()` tick
(30 min by default), and the web handler reads exclusively from that
cached row, never live from Docker. Manual container lifecycle changes
had no path to the UI faster than the next tick.

`internal/crashloop.Monitor` was already permanently subscribed to
Docker's event stream for crash-loop detection, so this reuses that
connection: on `start`/`stop`/`kill`/`die`/`pause`/`unpause`/`oom`, the
container's state is now written immediately via a new
`Store.SetContainerState`, independent of crash-loop logic. The periodic
check remains the fallback for anything the event stream misses
(reconnect gaps, daemon restarts).

`SetContainerState` only touches `state`/`status` — `UpsertSeen` isn't
reused here since a partial record would blow away `stack`,
`current_image` and `excluded` on conflict. An empty status is treated as
"leave it alone" so a lifecycle event without Docker's human-readable
status string (e.g. "Up 3 hours") doesn't blank a perfectly good display
value until the next full check.

Also fixed a `rows.Err()` check missing after the `notification_queue`
scan loop in the plaintext-secret migration (`secrets.go`) — an
interrupted iteration (as opposed to a clean end-of-rows) was silently
swallowed, so the transaction could commit having encrypted only part of
the queued secrets. Unrelated to the state-sync fix, spotted in the same
pass.

Confirmed while investigating: DoUpRo has no image-pruning mechanism
anywhere in the codebase — old images are never removed automatically,
so a rollback failing with "image not found" after a reboot isn't
something this tool did.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/crashloop/... ./internal/store/...`
- [x] Manual: `docker start`/`docker stop` a container outside DoUpRo,
      confirm the Containers page reflects the new state within a few
      seconds without a full 30-minute wait
