### PR TITLE
fix(scheduler,notifier): bound every periodic tick so a hung Docker/H…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ it reaches `1.0.0`.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-21
+
+### Fixed
+
+- The scheduler's periodic registry check and due-schedule execution could
+  freeze permanently: `Run`'s loop called `Check`/`runRelativePolicies`/
+  `runDueSchedules` synchronously with no per-tick deadline, so a single
+  Docker call that never returns (e.g. `Client.Pull` draining a stalled
+  `ImagePull` stream — the Docker SDK sets no timeout of its own) blocked
+  every future tick forever, with nothing logged, while the rest of the
+  daemon (API, manual actions) kept responding normally — indistinguishable
+  from "just not detecting updates" until compared against wall-clock time.
+  Each tick now runs in its own goroutine under a 20-minute timeout, and a
+  tick still running when the next one is due is skipped (logged as
+  `scheduler.tick_skipped`) rather than run concurrently against the same
+  containers/schedules.
+- The same class of bug existed in the notification delivery worker
+  (`internal/notifier`): its single-threaded loop called `shoutrrr.Send`
+  synchronously with no timeout, so one unresponsive webhook/bot endpoint
+  would silently stop delivery for every configured channel, not just the
+  slow one. `send` now runs with a 30-second timeout per attempt; a job
+  that times out is retried/dead-lettered like any other delivery failure.
+
+### Changed
+
+- The Go router's internal wildcard for the container-scoped API routes
+  (`/api/v1/containers/{id}`, `.../check`, `.../update`, `.../rollback`)
+  is now named `{name}`, matching what it's always actually matched
+  against (the container's name — never Docker's own container ID, which
+  changes on every recreate) and what `openapi.json` already documented.
+  No behavior change: the parameter accepted exactly the same values
+  before and after.
+
 ## [0.3.0] - 2026-08-21
 
 ### Fixed

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -76,18 +76,18 @@ func RegisterRoutes(mux *http.ServeMux, st *store.Store, upd *updater.Updater, n
 	mux.Handle("POST /api/v1/auth/password", protected(passwordLimiter.wrap(handleChangePassword(st, logger))))
 	mux.Handle("GET /api/v1/containers", withPermission(store.PermissionReadContainers, http.HandlerFunc(handleListContainers(st, upd))))
 	mux.Handle("GET /api/v1/logs", withPermission(store.PermissionViewLogs, http.HandlerFunc(handleListLogs(st))))
-	// {id} is matched against the container *name*, not Docker's container
-	// ID, which changes on every recreate — the name is what stays stable
-	// and what operators actually refer to (docs/cli.md examples all use
-	// the name, e.g. `doupro update adguard-home`).
-	mux.Handle("GET /api/v1/containers/{id}", withPermission(store.PermissionReadContainers, http.HandlerFunc(handleGetContainer(st, upd))))
-	mux.Handle("POST /api/v1/containers/{id}/check", withPermission(store.PermissionWriteContainers, http.HandlerFunc(handleCheckContainer(st, cli, logger, notif))))
+	// {name} is matched against the container *name*, not Docker's
+	// container ID, which changes on every recreate — the name is what
+	// stays stable and what operators actually refer to (docs/cli.md
+	// examples all use the name, e.g. `doupro update adguard-home`).
+	mux.Handle("GET /api/v1/containers/{name}", withPermission(store.PermissionReadContainers, http.HandlerFunc(handleGetContainer(st, upd))))
+	mux.Handle("POST /api/v1/containers/{name}/check", withPermission(store.PermissionWriteContainers, http.HandlerFunc(handleCheckContainer(st, cli, logger, notif))))
 	// GET previews exactly what POST on the same path would do — a
 	// read-only dry-run, gated on read (not write) access accordingly.
-	mux.Handle("GET /api/v1/containers/{id}/update", withPermission(store.PermissionReadContainers, http.HandlerFunc(handlePreviewUpdate(st))))
-	mux.Handle("POST /api/v1/containers/{id}/update", withPermission(store.PermissionWriteContainers, http.HandlerFunc(handleUpdateContainer(st, upd, resolveVer))))
-	mux.Handle("POST /api/v1/containers/{id}/rollback", withPermission(store.PermissionWriteContainers, http.HandlerFunc(handleRollbackContainer(st, upd, resolveVer))))
-	// A distinct path shape from {id}/update (one segment shorter), so
+	mux.Handle("GET /api/v1/containers/{name}/update", withPermission(store.PermissionReadContainers, http.HandlerFunc(handlePreviewUpdate(st))))
+	mux.Handle("POST /api/v1/containers/{name}/update", withPermission(store.PermissionWriteContainers, http.HandlerFunc(handleUpdateContainer(st, upd, resolveVer))))
+	mux.Handle("POST /api/v1/containers/{name}/rollback", withPermission(store.PermissionWriteContainers, http.HandlerFunc(handleRollbackContainer(st, upd, resolveVer))))
+	// A distinct path shape from {name}/update (one segment shorter), so
 	// there's no route-matching ambiguity with a container literally
 	// named "update-all".
 	mux.Handle("POST /api/v1/containers/update-all", withPermission(store.PermissionWriteContainers, http.HandlerFunc(handleUpdateAllContainers(st, upd, resolveVer, logger))))
@@ -219,7 +219,7 @@ func toContainerResponse(ctx context.Context, st *store.Store, upd *updater.Upda
 // tracked container, the same shape as one entry from the list endpoint.
 func handleGetContainer(st *store.Store, upd *updater.Updater) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		rec, err := st.GetContainerByName(r.Context(), r.PathValue("id"))
+		rec, err := st.GetContainerByName(r.Context(), r.PathValue("name"))
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "not_found", "container not found")
 			return
@@ -248,7 +248,7 @@ type checkResponse struct {
 // silently skips.
 func handleCheckContainer(st *store.Store, cli *docker.Client, logger *events.Logger, notif *notifier.Notifier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		checked, updateAvailable, err := scheduler.CheckOneContainerNow(r.Context(), logger, cli, st, notif, r.PathValue("id"))
+		checked, updateAvailable, err := scheduler.CheckOneContainerNow(r.Context(), logger, cli, st, notif, r.PathValue("name"))
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "not_found", "container not found")
 			return
@@ -341,7 +341,7 @@ type updatePreviewResponse struct {
 // concrete before/after before committing to it.
 func handlePreviewUpdate(st *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		rec, err := st.GetContainerByName(r.Context(), r.PathValue("id"))
+		rec, err := st.GetContainerByName(r.Context(), r.PathValue("name"))
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "not_found", "container not found")
 			return
@@ -376,7 +376,7 @@ func handlePreviewUpdate(st *store.Store) http.HandlerFunc {
 // the version strings for immediate display.
 func handleUpdateContainer(st *store.Store, upd *updater.Updater, resolveVer versionResolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		rec, err := st.GetContainerByName(r.Context(), r.PathValue("id"))
+		rec, err := st.GetContainerByName(r.Context(), r.PathValue("name"))
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "not_found", "container not found")
 			return
@@ -445,7 +445,7 @@ func respondSelfUpdate(w http.ResponseWriter, r *http.Request, err error) {
 // for immediate display.
 func handleRollbackContainer(st *store.Store, upd *updater.Updater, resolveVer versionResolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		rec, err := st.GetContainerByName(r.Context(), r.PathValue("id"))
+		rec, err := st.GetContainerByName(r.Context(), r.PathValue("name"))
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "not_found", "container not found")
 			return

--- a/internal/api/containers_test.go
+++ b/internal/api/containers_test.go
@@ -92,7 +92,7 @@ func TestHandleGetContainerReturnsDetailForKnownContainer(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/containers/grav", nil)
-	req.SetPathValue("id", "grav")
+	req.SetPathValue("name", "grav")
 	resp := httptest.NewRecorder()
 	handleGetContainer(st, upd)(resp, req)
 
@@ -108,7 +108,7 @@ func TestHandleGetContainerNotFound(t *testing.T) {
 	st, upd := newTestStoreAndUpdater(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/containers/nope", nil)
-	req.SetPathValue("id", "nope")
+	req.SetPathValue("name", "nope")
 	resp := httptest.NewRecorder()
 	handleGetContainer(st, upd)(resp, req)
 
@@ -123,7 +123,7 @@ func TestHandleCheckContainerNotFound(t *testing.T) {
 	notif := notifier.New(st, logger)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/containers/nope/check", nil)
-	req.SetPathValue("id", "nope")
+	req.SetPathValue("name", "nope")
 	resp := httptest.NewRecorder()
 	// A nil *docker.Client is safe here: CheckOneContainerNow resolves
 	// store.ErrNotFound from st.GetContainerByName before it ever touches
@@ -161,7 +161,7 @@ func TestHandlePreviewUpdateResolvesCandidateWithoutMutatingAnything(t *testing.
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/containers/grav/update", nil)
-	req.SetPathValue("id", "grav")
+	req.SetPathValue("name", "grav")
 	resp := httptest.NewRecorder()
 	handlePreviewUpdate(st)(resp, req)
 
@@ -212,7 +212,7 @@ func TestHandlePreviewUpdateDoesNotShowARawFloatingTagAsATargetVersion(t *testin
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/containers/grav/update", nil)
-	req.SetPathValue("id", "grav")
+	req.SetPathValue("name", "grav")
 	resp := httptest.NewRecorder()
 	handlePreviewUpdate(st)(resp, req)
 
@@ -228,7 +228,7 @@ func TestHandlePreviewUpdateRejectsBadSemverScope(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/containers/grav/update?semver=bogus", nil)
-	req.SetPathValue("id", "grav")
+	req.SetPathValue("name", "grav")
 	resp := httptest.NewRecorder()
 	handlePreviewUpdate(st)(resp, req)
 

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -137,6 +137,7 @@ type Notifier struct {
 	lease        time.Duration
 	baseBackoff  time.Duration
 	maxBackoff   time.Duration
+	sendTimeout  time.Duration
 }
 
 // New builds a Notifier backed by st for channel config and the
@@ -148,7 +149,7 @@ func New(st *store.Store, loggers ...*events.Logger) *Notifier {
 	}
 	return &Notifier{store: st, logger: logger, send: shoutrrr.Send,
 		pollInterval: time.Second, lease: 2 * time.Minute,
-		baseBackoff: time.Minute, maxBackoff: time.Hour}
+		baseBackoff: time.Minute, maxBackoff: time.Hour, sendTimeout: 30 * time.Second}
 }
 
 // Channels returns the currently configured channels.
@@ -304,12 +305,33 @@ func (n *Notifier) Run(ctx context.Context) {
 	}
 }
 
+// sendWithTimeout calls n.send in its own goroutine and waits up to
+// sendTimeout for it to return, so one unresponsive webhook/bot endpoint
+// (shoutrrr's underlying HTTP clients set no request timeout of their own —
+// same shape as the internal/docker.Client.Pull hang this mirrors the fix
+// for) can never block Run's single-threaded delivery loop past this one
+// job — without this, a single stuck channel would silently stop
+// notification delivery for every channel, forever. n.send itself is a
+// plain func(string, string) error with no context parameter, so it can't
+// be cancelled once started; a leaked goroutine on timeout is the accepted
+// cost of not blocking the worker loop indefinitely.
+func (n *Notifier) sendWithTimeout(channelURL, message string) error {
+	result := make(chan error, 1)
+	go func() { result <- n.send(channelURL, message) }()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(n.sendTimeout):
+		return fmt.Errorf("send notification: timed out after %s", n.sendTimeout)
+	}
+}
+
 func (n *Notifier) deliverOne(ctx context.Context) (bool, error) {
 	job, err := n.store.ClaimNotification(ctx, time.Now(), n.lease)
 	if err != nil || job == nil {
 		return false, err
 	}
-	sendErr := n.send(job.ChannelURL, job.Message)
+	sendErr := n.sendWithTimeout(job.ChannelURL, job.Message)
 	status, errText := "sent", ""
 	if sendErr == nil {
 		now := time.Now().UTC()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	cron "github.com/robfig/cron/v3"
@@ -26,6 +27,19 @@ const DefaultCheckInterval = 30 * time.Minute
 // the next full registry check to be noticed.
 const dueTickInterval = 30 * time.Second
 
+// tickTimeout bounds a single scheduler tick (a full Check() sweep, or a
+// runRelativePolicies pass). Run's select loop is single-threaded and
+// re-arms checkTimer only after its case returns (see Run), so a Docker
+// call that hangs indefinitely — e.g. Client.Pull draining a stalled
+// ImagePull stream, which has no timeout of its own (see
+// internal/docker.Client) — would otherwise freeze every future tick
+// forever: no more registry checks, no more due-schedule execution, with
+// no crash or error logged, since nothing ever returns to observe. A
+// generous but finite ceiling here guarantees the loop always gets back
+// to select, even in that worst case, at the cost of that one tick's
+// results being incomplete.
+const tickTimeout = 20 * time.Minute
+
 // Scheduler runs the periodic registry check and executes one-off and
 // recurring schedules. See docs/schedule.md.
 type Scheduler struct {
@@ -35,6 +49,11 @@ type Scheduler struct {
 	logger        *events.Logger
 	notifier      *notifier.Notifier
 	checkInterval time.Duration
+
+	// ticking guards against two ticks (a checkTimer fire and a dueTicker
+	// fire) running concurrently against the same containers/schedules —
+	// see runTick.
+	ticking atomic.Bool
 }
 
 // New builds a Scheduler. All dependencies must already be open/connected.
@@ -63,14 +82,44 @@ func (s *Scheduler) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-checkTimer.C:
-			Check(ctx, s.logger, s.docker, s.store, s.notifier)
-			s.runRelativePolicies(ctx)
+			s.runTick(ctx, func(tickCtx context.Context) {
+				Check(tickCtx, s.logger, s.docker, s.store, s.notifier)
+				s.runRelativePolicies(tickCtx)
+			})
 			checkTimer.Reset(s.currentCheckInterval(ctx))
 		case <-dueTicker.C:
-			s.runDueSchedules(ctx)
-			s.runRelativePolicies(ctx)
+			s.runTick(ctx, func(tickCtx context.Context) {
+				s.runDueSchedules(tickCtx)
+				s.runRelativePolicies(tickCtx)
+			})
 		}
 	}
+}
+
+// runTick runs fn in its own goroutine, under a context bounded by
+// tickTimeout, and returns immediately — so Run's select loop always comes
+// back around on schedule no matter what happens inside fn, even in the
+// worst case where a Docker/registry call ignores context cancellation
+// entirely (tickTimeout's doc comment covers the ordinary case where
+// cancellation is honored; this covers the case where it isn't). Skips
+// starting a new tick while a previous one is still running, rather than
+// running them concurrently against the same containers/schedules — a
+// still-hung previous tick just means this tick (and any after it, until
+// the hang eventually resolves or the process restarts) is silently
+// skipped, which is the same "stale until it recovers" behavior the code
+// already had before this fix, not a new failure mode.
+func (s *Scheduler) runTick(ctx context.Context, fn func(context.Context)) {
+	if !s.ticking.CompareAndSwap(false, true) {
+		s.logger.Emit(ctx, events.Event{Level: events.LevelWarn, Type: "scheduler.tick_skipped", Actor: events.ActorSystem,
+			Message: "skipped a scheduler tick: the previous one is still running"})
+		return
+	}
+	go func() {
+		defer s.ticking.Store(false)
+		tickCtx, cancel := context.WithTimeout(ctx, tickTimeout)
+		defer cancel()
+		fn(tickCtx)
+	}()
 }
 
 // currentCheckInterval reads Settings -> General's check interval, or


### PR DESCRIPTION
## Summary

- The scheduler's `Run` loop called `Check`/`runRelativePolicies`/`runDueSchedules`
  synchronously with no per-tick deadline. A single Docker call that never returns
  (`Client.Pull` draining a stalled `ImagePull` stream — the Docker SDK sets no
  timeout of its own) froze every future tick permanently, silently, while the rest
  of the daemon (API, manual actions) kept responding normally. This is exactly what
  stopped a production instance from detecting its own `0.3.0` update for two hours —
  confirmed in logs: last `containers.checked` fired, then nothing, despite a
  10-minute check interval, until the container was manually restarted.
- Each tick now runs in its own goroutine under a 20-minute timeout; a tick still
  running when the next is due is skipped (logged `scheduler.tick_skipped`) instead
  of running concurrently against the same containers/schedules.
- The same bug class existed in the notification delivery worker: a single-threaded
  loop calling `shoutrrr.Send` with no timeout meant one unresponsive webhook/bot
  endpoint would silently stop delivery for *every* configured channel forever.
  `send` now has a 30-second timeout per attempt; a timeout is retried/dead-lettered
  like any other delivery failure.
- Renamed the container-route path parameter from `{id}` to `{name}` in
  `internal/api/api.go` — cosmetic only, no behavior change. It always meant the
  container's name (already documented as such in `openapi.json`), never Docker's
  own container ID.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race`
- [x] Verified live on the homelab: root cause reproduced from production logs
      (check stopped at 06:06:58 UTC, resumed only after manual restart), and the
      full detection → self-update flow re-verified end-to-end on a disposable
      `sharlihe/doupro:0.2.0` container after the fix (correctly detected `0.3.0`,
      completed a full self-update in ~8s).
