### PR TITLE
feat(web): add Updatable filter button on Containers page

### DIFF
--- a/web/static/stacks.js
+++ b/web/static/stacks.js
@@ -49,6 +49,49 @@
   }
 })();
 
+// "Updatable" filter on the Containers page. Toggles visibility of
+// container rows that have no update available, hiding whole stacks that
+// end up empty as a result while leaving their toggle/dropdown intact for
+// when the filter is switched off again. Purely client-side, no reload.
+(function () {
+  function wireUpdatableFilter() {
+    var button = document.getElementById('updatable-filter-btn');
+    if (!button) return;
+
+    var active = false;
+
+    function apply() {
+      document.querySelectorAll('[data-stack]').forEach(function (section) {
+        var rows = section.querySelectorAll('[data-container-row]');
+        var visibleCount = 0;
+
+        rows.forEach(function (row) {
+          var show = !active || row.dataset.updatable === '1';
+          row.classList.toggle('hidden', !show);
+          if (show) visibleCount++;
+        });
+
+        section.classList.toggle('hidden', active && visibleCount === 0);
+      });
+    }
+
+    button.addEventListener('click', function () {
+      active = !active;
+      button.textContent = active ? 'All' : 'Updatable';
+      button.title = active
+        ? 'Show all containers'
+        : 'Show only containers with an update available';
+      apply();
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wireUpdatableFilter);
+  } else {
+    wireUpdatableFilter();
+  }
+})();
+
 // Show a donut progress spinner while update/rollback operations are running.
 // Replaces the button with a spinner, makes an AJAX request, and reloads
 // the page on success. This gives immediate visual feedback instead of

--- a/web/templates/containers.html
+++ b/web/templates/containers.html
@@ -6,6 +6,7 @@
       {{if .CanWriteContainers}}
       <button type="button" id="update-all-btn" class="update-all-btn text-xs px-2.5 py-1 rounded border border-gray-700 text-gray-300 hover:bg-gray-800" title="Update every container with an update available, except exclusions">Update all</button>
       {{end}}
+      <button type="button" id="updatable-filter-btn" class="text-xs px-2.5 py-1 rounded border border-gray-700 text-gray-300 hover:bg-gray-800" title="Show only containers with an update available">Updatable</button>
       <div class="text-sm text-gray-500">{{.Total}} tracked</div>
     </div>
   </div>
@@ -39,7 +40,7 @@
     </div>
     <div class="stack-body rounded-lg border border-gray-800 divide-y divide-gray-800 overflow-hidden">
       {{range .Containers}}
-      <div class="flex items-center gap-4 px-4 py-3 bg-gray-900/40 flex-wrap {{if .Excluded}}opacity-50{{end}}">
+      <div class="flex items-center gap-4 px-4 py-3 bg-gray-900/40 flex-wrap {{if .Excluded}}opacity-50{{end}}" data-container-row data-updatable="{{if .UpdateAvailable}}1{{else}}0{{end}}">
         <span class="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-full shrink-0
           {{if eq .StateClass "running"}}bg-state-running/15 text-state-running
           {{else if eq .StateClass "created"}}bg-state-created/15 text-state-created


### PR DESCRIPTION
Adds an "Updatable" toggle next to "Update all" that hides container rows without an available update, collapsing stacks left empty by the filter while keeping their toggle/dropdown for when it's switched off. Purely client-side (no reload). Toggling flips the button to "All" so clicking again restores the full list.

Closes #21

## What & why

As per request on the issue #21, having a way to only show the updatable services is a great idea.

## Related issue

<!-- Closes #123 -->

